### PR TITLE
StampDetailVC 개요 텍스트레이블 행간 수정

### DIFF
--- a/MICE/View/StampDetailViewController.swift
+++ b/MICE/View/StampDetailViewController.swift
@@ -9,6 +9,20 @@ import UIKit
 import SnapKit
 import Kingfisher
 
+extension UILabel {
+    func setLineSpacing(_ spacing: CGFloat) {
+        guard let text = self.text, !text.isEmpty else { return }
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = spacing
+        let attributes: [NSAttributedString.Key: Any] = [
+            .paragraphStyle: paragraphStyle,
+            .font: self.font as Any,
+            .foregroundColor: self.textColor as Any
+        ]
+        self.attributedText = NSAttributedString(string: text, attributes: attributes)
+    }
+}
+
 class StampDetailViewController: UIViewController {
     
     var isBookmarked = false
@@ -68,6 +82,7 @@ class StampDetailViewController: UIViewController {
     
     //개요(라벨)
     let overviewLabel = UILabel()
+    
     
     //개요(내용)
     let overviewContentLabel = UILabel()
@@ -277,6 +292,8 @@ class StampDetailViewController: UIViewController {
             overviewContentLabel.text = "내용 없음"
         }
         overviewContentLabel.numberOfLines = 0
+        overviewContentLabel.setLineSpacing(8)
+        
         
         //스탬프획득하기(버튼)
         getStampButton.setTitle("스탬프 획득하기", for: .normal)


### PR DESCRIPTION
| Before(행간수정 전) | After(행간 사이즈 8) |
|---|---|
| ![before](<https://github.com/user-attachments/assets/0c488399-93f1-45a7-822a-ad02f1d87d70>) | ![after](<https://github.com/user-attachments/assets/921830bd-5c13-405a-9fb1-5ab4c77fa6c3>) |

개요 콘텐츠 텍스트 행간이 너무 좁아서 가독성이 떨어진다는 의견이 있어서 행간 조절했습니다.
