### PR TITLE
유저 로그 저장기능 추가, 스탬프디테일뷰 버그 수정

### DIFF
--- a/MICE/App/AppDelegate.swift
+++ b/MICE/App/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // 앱 실행 후 초기 설정을 진행하는 지점
         locationManager.delegate = self
-        checkLocationPermissionIfNeeded()
+        locationManager.requestWhenInUseAuthorization()
         return true
     }
 
@@ -32,34 +32,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
         // 사용자가 씬 세션을 삭제했을 때 호출됨
         // 앱이 실행되지 않는 동안 삭제된 씬 세션도 이 메서드를 통해 정리됨
         // 삭제된 씬과 관련된 리소스를 해제하는 데 사용
-    }
-
-    private func checkLocationPermissionIfNeeded() {
-        let isFirstLaunch = !UserDefaults.standard.bool(forKey: "hasLaunchedBefore")
-
-        if isFirstLaunch {
-            UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
-            showLocationAlert()
-        }
-    }
-
-    private func showLocationAlert() {
-        let alert = UIAlertController(
-            title: "위치정보 사용 안내",
-            message: "MICE 앱은 위치 기반 추천 및 서비스를 위해 위치정보를 사용합니다. 위치 권한을 허용해 주세요.",
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "허용", style: .default, handler: { _ in
-            self.locationManager.requestWhenInUseAuthorization()
-        }))
-        alert.addAction(UIAlertAction(title: "나중에", style: .cancel))
-
-        DispatchQueue.main.async {
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let rootVC = windowScene.windows.first?.rootViewController {
-                rootVC.present(alert, animated: true)
-            }
-        }
     }
 
 }

--- a/MICE/App/SceneDelegate.swift
+++ b/MICE/App/SceneDelegate.swift
@@ -14,24 +14,24 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        
-        // MARK: - 변경점: Notification Observer 추가
-        // MypageViewModel에서 보낸 로그아웃 신호를 받기 위해 Observer를 등록합니다.
-        NotificationCenter.default.addObserver(self, selector: #selector(handleLogout), name: .didRequestLogout, object: nil)
-        
-        // MARK: - 변경점: '첫 실행'이 아닌 '로그인 상태'로 초기 화면 결정
-        // UserSession을 통해 현재 로그인 되어있는지 확인합니다.
-        let isLoggedIn = UserSession.shared.isLoggedIn
-        
-        if isLoggedIn {
-            // 로그인이 되어 있으면 홈 화면(MainTabBarController)으로 바로 이동
-            window?.rootViewController = MainTabBarController()
-        } else {
-            // 로그인이 안 되어 있으면 로그인 화면으로 이동
-            window?.rootViewController = LogInViewController(launchSource: .firstInstall)
-        }
-        
+
+        // 기본적으로 로딩 화면 먼저 띄우기
+        window?.rootViewController = SplashViewController()
         window?.makeKeyAndVisible()
+
+        Task {
+            if let session = try? await SupabaseManager.shared.client.auth.session, session.user != nil {
+                // 세션이 있으면 메인 화면으로
+                DispatchQueue.main.async {
+                    self.window?.rootViewController = MainTabBarController()
+                }
+            } else {
+                // 세션이 없으면 로그인 화면으로
+                DispatchQueue.main.async {
+                    self.window?.rootViewController = LogInViewController(launchSource: .firstInstall)
+                }
+            }
+        }
     }
     
     // MARK: - 추가된 함수: 로그아웃 처리 및 화면 전환

--- a/MICE/Info.plist
+++ b/MICE/Info.plist
@@ -9,7 +9,7 @@
 	<key>SUPABASE_URL</key>
 	<string>$(SUPABASE_URL)</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>위치 기반 추천 및 서비스를 위해 위치정보를 사용합니다.</string>
+	<string>가까운 스탬프 추천 및 스탬프 획득을 위해 위치정보를 사용합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/MICE/Service/SupabaseManager.swift
+++ b/MICE/Service/SupabaseManager.swift
@@ -8,6 +8,34 @@
 import Foundation
 import Supabase
 
+
+struct EventLogger {
+    struct EventDetail: Encodable {
+        let button: String
+        let screen: String
+    }
+
+    struct UserLog: Encodable {
+        let user_id: String
+        let event_type: String
+        let event_detail: EventDetail
+    }
+
+    static func logButtonClick(userId: String, buttonName: String, screen: String) async {
+        let client = SupabaseManager.shared.client
+        let detail = EventDetail(button: buttonName, screen: screen)
+        let log = UserLog(user_id: userId, event_type: "button_click", event_detail: detail)
+        do {
+            try await client
+                .from("user_logs")
+                .insert(log)
+                .execute()
+        } catch {
+            print("로그 저장 실패: \(error)")
+        }
+    }
+}
+
 struct User: Encodable {
     // The 'id' field stores UUID strings representing unique user identifiers.
     let id: UUID

--- a/MICE/Service/SupabaseManager.swift
+++ b/MICE/Service/SupabaseManager.swift
@@ -30,7 +30,13 @@ class SupabaseManager {
         let supabaseUrl = URL(string: value2)!
         self.baseURL = supabaseUrl
         let supabaseKey = value
-        self.supabase = SupabaseClient(supabaseURL: supabaseUrl, supabaseKey: supabaseKey)
+        self.supabase = SupabaseClient(
+            supabaseURL: supabaseUrl,
+            supabaseKey: supabaseKey
+        )
+        
+        print("DEBUG [SupabaseManager.init] currentSession:", supabase.auth.currentSession as Any) // 디버깅로그
+        print("DEBUG [SupabaseManager.init] currentUser:", supabase.auth.currentUser as Any) // 디버깅로그
     }
 
     func registerOrUpdateUser(appleUID: String, name: String?, email: String?, provider: String) {
@@ -134,6 +140,9 @@ class SupabaseManager {
             let session = try await supabase.auth.signInWithIdToken(
                 credentials: .init(provider: .apple, idToken: idToken, nonce: nonce)
             )
+            
+            print("DEBUG [signInWithApple] session:", session) // 디버깅로그
+            
             return session
         } catch {
             print("Apple 로그인 실패: \(error)")

--- a/MICE/View/SplashViewController.swift
+++ b/MICE/View/SplashViewController.swift
@@ -1,0 +1,54 @@
+//
+//  SplashViewController.swift
+//  MICE
+//
+//  Created by 이돈혁 on 9/18/25.
+//
+
+import UIKit
+
+class SplashViewController: UIViewController {
+    private let label: UILabel = {
+        let label = UILabel()
+        label.text = "로딩 중..."
+        label.textAlignment = .center
+        label.alpha = 0
+        return label
+    }()
+    
+    private let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.startAnimating()
+        return indicator
+    }()
+    
+    private let stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.alignment = .center
+        return stack
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        
+        stackView.addArrangedSubview(label)
+        stackView.addArrangedSubview(activityIndicator)
+        view.addSubview(stackView)
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        UIView.animate(withDuration: 1.0) {
+            self.label.alpha = 1.0
+        }
+    }
+}

--- a/MICE/View/StampDetailViewController.swift
+++ b/MICE/View/StampDetailViewController.swift
@@ -178,7 +178,7 @@ class StampDetailViewController: UIViewController {
                         self.getStampButton.backgroundColor = UIColor(red: 114/255, green: 76/255, blue: 249/255, alpha: 1)
                     } else {
                         self.getStampButton.setTitle("스탬프 획득하기", for: .normal)
-                        self.getStampButton.isEnabled = false
+                        self.getStampButton.isEnabled = true
                         self.getStampButton.setTitleColor(UIColor(red: 117/255, green: 117/255, blue: 117/255, alpha: 1), for: .normal)
                         self.getStampButton.backgroundColor = UIColor(red: 235/255, green: 235/255, blue: 235/255, alpha: 1)
                     }

--- a/MICE/ViewModel/LoginViewModel.swift
+++ b/MICE/ViewModel/LoginViewModel.swift
@@ -49,7 +49,16 @@ final class LoginViewModel {
                             print("idToken 변환 실패")
                             return
                         }
-                        _ = try await SupabaseManager.shared.signInWithApple(idToken: idTokenString, nonce: nil)
+                        let session = try await SupabaseManager.shared.signInWithApple(idToken: idTokenString, nonce: nil)
+
+                        // 사용자 등록/업데이트 호출
+                        try await SupabaseManager.shared.registerOrUpdateUser(
+                            appleUID: appleUID,
+                            name: session.user.userMetadata["name"] as? String,
+                            email: session.user.userMetadata["email"] as? String,
+                            provider: "apple"
+                        )
+
                         if SupabaseManager.shared.isLoggedIn() {
                             self?.outputSubject.send(.navigateToMain)
                         }

--- a/MICE/ViewModel/StampDetailViewModel.swift
+++ b/MICE/ViewModel/StampDetailViewModel.swift
@@ -12,6 +12,13 @@ class StampDetailViewModel {
     private let unlockDistance: Double = 400.0 // 기준 거리
     private var targetStamp: Stamp?
 
+    // VC가 구독할 콜백: 400m 이내 여부(true/false)
+    var onProximityUpdate: ((Bool) -> Void)?
+
+    // 지속 모니터링 제어용
+    private var monitorTask: Task<Void, Never>?
+    private let monitorIntervalNs: UInt64 = 2_000_000_000 // 2초 간격
+
     enum UnlockResult {
         case success(Date)
         case tooFar
@@ -54,5 +61,24 @@ class StampDetailViewModel {
             print("addMyStamp 실패:", error)   // 디버깅 로그
             return .failed
         }
+    }
+
+    /// 상세 화면 진입 시 호출: 주기적으로 canUnlockStamp()를 확인하여 콜백으로 전달
+    func startProximityMonitoring() {
+        monitorTask?.cancel()
+        monitorTask = Task { [weak self] in
+            guard let self = self else { return }
+            while !Task.isCancelled {
+                let can = await self.canUnlockStamp()
+                await MainActor.run { self.onProximityUpdate?(can) }
+                try? await Task.sleep(nanoseconds: self.monitorIntervalNs)
+            }
+        }
+    }
+
+    /// 상세 화면 이탈 시 호출: 모니터링 중단
+    func stopProximityMonitoring() {
+        monitorTask?.cancel()
+        monitorTask = nil
     }
 }


### PR DESCRIPTION
원래 튜터님 제안으로 firebase로 로그저장기능 추가하려다가 시간 내 못끝낼거같아서 일단 supabase 이용하도록 만들었어요
스탬프디테일뷰 수정이 계속 꼬이고있어서 이번에도 핫픽스에 업로드합니다
계속 하나빼기하듯이 하나가 고쳐지면 하나가 망가지네요(스탬프획득 가능하도록 수정하면 버튼 비활성화가 아예 풀려버림 or 버튼 비활성화를 정상화하면 획득한 후 화면출력이 망가짐)
유저 로그는 supabase의 user_logs 테이블에서 확인 가능합니다
마지막 커밋은 스탬프 획득 로직 완성시켰습니다